### PR TITLE
[Feature] 네모 getPrice 구현

### DIFF
--- a/src/main/java/NemoTradingSystem.java
+++ b/src/main/java/NemoTradingSystem.java
@@ -6,6 +6,10 @@ public class NemoTradingSystem implements TradingSystem{
     private String pw;
     private NemoApi nemoApi;
 
+    public NemoTradingSystem() {
+        this.nemoApi = new NemoApi();
+    }
+
     public NemoTradingSystem(NemoApi nemoApi) {
         this.nemoApi = nemoApi;
     }
@@ -40,5 +44,9 @@ public class NemoTradingSystem implements TradingSystem{
         } catch (Exception e) {
             return String.format("%s 매수 중 오류 발생: %s", stockCode, e.getMessage());
         }
+    }
+
+    public int getPrice(String stockCode) throws InterruptedException {
+        return nemoApi.getMarketPrice(stockCode, 1);
     }
 }

--- a/src/test/java/NemoTradingSystemTest.java
+++ b/src/test/java/NemoTradingSystemTest.java
@@ -5,6 +5,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class NemoTradingSystemTest {
@@ -58,6 +59,18 @@ class NemoTradingSystemTest {
         int price = 1000;
         String actual = app.buy(stockCode,count,price);
         String expected = String.format("%s를 %d 가격에 매수하였음", stockCode,price);
+        assertEquals(actual, expected);
+    }
+
+    @Test
+    void nemogetprice() {
+        String stockCode = "T02";
+        int expected = 2000;
+        when(nemoApi.currentPrice(stockCode)).thenReturn(expected);
+
+        KiumTradingSystem app = new KiumTradingSystem(nemoApi);
+        int actual = app.getPrice(stockCode);
+
         assertEquals(actual, expected);
     }
 }

--- a/src/test/java/NemoTradingSystemTest.java
+++ b/src/test/java/NemoTradingSystemTest.java
@@ -63,12 +63,12 @@ class NemoTradingSystemTest {
     }
 
     @Test
-    void nemogetprice() {
+    void nemogetprice() throws InterruptedException {
         String stockCode = "T02";
         int expected = 2000;
-        when(nemoApi.currentPrice(stockCode)).thenReturn(expected);
+        when(nemoApi.getMarketPrice(stockCode,1)).thenReturn(expected);
 
-        KiumTradingSystem app = new KiumTradingSystem(nemoApi);
+        NemoTradingSystem app = new NemoTradingSystem(nemoApi);
         int actual = app.getPrice(stockCode);
 
         assertEquals(actual, expected);


### PR DESCRIPTION
# 내용
- NemoAPI의 getMarketPrice 함수 호출하는 부분 구현
- KiwerAPI와의 통일성을 위해 minute 값은 입력 받지 않고 1로 고정
- 테스트: PASS
![image](https://github.com/user-attachments/assets/3d5afb69-5027-4127-b80c-ce1e4480eb51)
